### PR TITLE
[feat] fastAPI 서버로 openfeign을 통해 입장코드를 보내는 기능 완료

### DIFF
--- a/src/main/java/com/example/gonggang/admin/api/AdminController.java
+++ b/src/main/java/com/example/gonggang/admin/api/AdminController.java
@@ -2,9 +2,9 @@ package com.example.gonggang.admin.api;
 
 import com.example.gonggang.admin.application.AppointmentManagerService;
 import com.example.gonggang.domain.appointment.application.AppointmentBoardGetService;
-import com.example.gonggang.domain.appointment.application.AppointmentManageService;
 import com.example.gonggang.domain.appointment.dto.response.AllAppointmentBoardResponse;
 import com.example.gonggang.global.config.success.SuccessCode;
+
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/example/gonggang/admin/api/AdminController.java
+++ b/src/main/java/com/example/gonggang/admin/api/AdminController.java
@@ -50,19 +50,19 @@ public class AdminController implements AdminApi {
 		return ResponseEntity.ok().body("ok");
 	}
 
-	@GetMapping("/get-members")
+	@GetMapping("/members")
 	public ResponseEntity<List<ReadAllMemberResponse>> findAll() {
 		List<ReadAllMemberResponse> response = userManageService.readAll();
 		return ResponseEntity.ok(response);
 	}
 
-	@GetMapping("/delete/{email}")
+	@DeleteMapping("/{email}")
 	public ResponseEntity<String> delete(@PathVariable String email) {
 		userManageService.delete(email);
 		return ResponseEntity.ok(SuccessCode.DELETE_SUCCESS.getMessage());
 	}
 
-	@GetMapping("get-appointmentBoards")
+	@GetMapping("/appointmentBoards")
 	public ResponseEntity<AllAppointmentBoardResponse> readAll() {
 		AllAppointmentBoardResponse response = appointmentManagerService.readAll();
 		return ResponseEntity.ok(response);

--- a/src/main/java/com/example/gonggang/admin/domain/Admin.java
+++ b/src/main/java/com/example/gonggang/admin/domain/Admin.java
@@ -4,6 +4,8 @@ import com.example.gonggang.domain.users.domain.Role;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,7 +29,8 @@ public class Admin {
 	@Column(nullable = false)
 	private String adminPassword;
 
-	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	@Column(columnDefinition = "varchar(10) default 'ADMIN'", nullable = false)
 	Role role;
 
 	@Builder

--- a/src/main/java/com/example/gonggang/domain/appointment/api/AppointmentController.java
+++ b/src/main/java/com/example/gonggang/domain/appointment/api/AppointmentController.java
@@ -9,10 +9,14 @@ import com.example.gonggang.domain.appointment.dto.response.AppointmentAllRespon
 import com.example.gonggang.domain.appointment.dto.response.AppointmentCreateResponse;
 import com.example.gonggang.domain.appointment.dto.response.AppointmentRemainingResponse;
 import com.example.gonggang.domain.appointment.dto.response.AppointmentsGetResponse;
+import com.example.gonggang.domain.external.fast_api.application.FastApiService;
 import com.example.gonggang.global.auth.annotation.CurrentMember;
 import com.example.gonggang.global.config.success.SuccessCode;
+
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,50 +30,53 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/appointment")
 @RequiredArgsConstructor
 public class AppointmentController {
-    private final AppointmentManageService appointmentManageService;
+	private final AppointmentManageService appointmentManageService;
+	private final FastApiService fastApiService;
 
-    @PostMapping()
-    public ResponseEntity<AppointmentCreateResponse> create(@CurrentMember Long userId,
-                                                            @RequestBody AppointmentCreateRequest appointmentCreateRequest) {
-        AppointmentCreateResponse result = appointmentManageService.create(userId, appointmentCreateRequest);
-        return ResponseEntity.ok(result);
-    }
+	@PostMapping()
+	public ResponseEntity<AppointmentCreateResponse> create(@CurrentMember Long userId,
+		@RequestBody AppointmentCreateRequest appointmentCreateRequest) {
+		AppointmentCreateResponse result = appointmentManageService.create(userId, appointmentCreateRequest);
 
-    @PostMapping("/enter")
-    public ResponseEntity<String> create(@CurrentMember Long userId,
-                                       @RequestBody AppointmentEnterRequest appointmentEnterRequest) {
+		return ResponseEntity.ok(result);
+	}
 
-        appointmentManageService.enter(userId, appointmentEnterRequest);
-        return ResponseEntity.ok(ENTER_SUCCESS.getMessage());
-    }
+	@PostMapping("/enter")
+	public ResponseEntity<String> create(@CurrentMember Long userId,
+		@RequestBody AppointmentEnterRequest appointmentEnterRequest) {
 
-    @GetMapping
-    public ResponseEntity<List<AppointmentsGetResponse>> readAll(@CurrentMember Long userId) {
-        List<AppointmentsGetResponse> result = appointmentManageService.readAll(userId);
-        return ResponseEntity.ok(result);
-    }
+		appointmentManageService.enter(userId, appointmentEnterRequest);
+		return ResponseEntity.ok(ENTER_SUCCESS.getMessage());
+	}
 
-    @GetMapping("/{roomId}")
-    public ResponseEntity<String> delete(@CurrentMember Long userId, @PathVariable Long roomId) {
-        appointmentManageService.delete(userId,roomId);
-        return ResponseEntity.ok("성공");
-    }
+	@GetMapping
+	public ResponseEntity<List<AppointmentsGetResponse>> readAll(@CurrentMember Long userId) {
+		List<AppointmentsGetResponse> result = appointmentManageService.readAll(userId);
+		return ResponseEntity.ok(result);
+	}
 
-    @GetMapping("/remaining-count/{roomId}")
-    public ResponseEntity<AppointmentRemainingResponse> read(@CurrentMember Long userId, @PathVariable Long roomId) {
-        AppointmentRemainingResponse response = appointmentManageService.read(userId, roomId);
-        return ResponseEntity.ok(response);
-    }
+	@GetMapping("/{roomId}")
+	public ResponseEntity<String> delete(@CurrentMember Long userId, @PathVariable Long roomId) {
+		appointmentManageService.delete(userId, roomId);
+		return ResponseEntity.ok("성공");
+	}
 
-    @PutMapping("/update-setting/{roomId}")
-    public ResponseEntity<String> update(@CurrentMember Long userId, @PathVariable Long roomId, @RequestBody AppointmentCreateRequest request) {
-        appointmentManageService.update(userId, roomId, request);
-        return ResponseEntity.ok(SuccessCode.UPDATE_SUCCESS.getMessage());
-    }
+	@GetMapping("/remaining-count/{roomId}")
+	public ResponseEntity<AppointmentRemainingResponse> read(@CurrentMember Long userId, @PathVariable Long roomId) {
+		AppointmentRemainingResponse response = appointmentManageService.read(userId, roomId);
+		return ResponseEntity.ok(response);
+	}
 
-    @GetMapping("/all")
-    public ResponseEntity<AppointmentAllResponse> read(@CurrentMember Long userId) {
-        AppointmentAllResponse response = appointmentManageService.read(userId);
-        return ResponseEntity.ok(response);
-    }
+	@PutMapping("/update-setting/{roomId}")
+	public ResponseEntity<String> update(@CurrentMember Long userId, @PathVariable Long roomId,
+		@RequestBody AppointmentCreateRequest request) {
+		appointmentManageService.update(userId, roomId, request);
+		return ResponseEntity.ok(SuccessCode.UPDATE_SUCCESS.getMessage());
+	}
+
+	@GetMapping("/all")
+	public ResponseEntity<AppointmentAllResponse> read(@CurrentMember Long userId) {
+		AppointmentAllResponse response = appointmentManageService.read(userId);
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/com/example/gonggang/domain/appointment/api/AppointmentController.java
+++ b/src/main/java/com/example/gonggang/domain/appointment/api/AppointmentController.java
@@ -11,6 +11,7 @@ import com.example.gonggang.domain.appointment.dto.response.AppointmentCreateRes
 import com.example.gonggang.domain.appointment.dto.response.AppointmentRemainingResponse;
 import com.example.gonggang.domain.appointment.dto.response.AppointmentsGetResponse;
 import com.example.gonggang.domain.external.fast_api.application.FastApiService;
+import com.example.gonggang.domain.external.fast_api.dto.FastApiResponse;
 import com.example.gonggang.global.auth.annotation.CurrentMember;
 import com.example.gonggang.global.config.success.SuccessCode;
 
@@ -35,10 +36,12 @@ public class AppointmentController {
 	private final FastApiService fastApiService;
 
     @PostMapping()
-    public ResponseEntity<AppointmentCreateResponse> create(@CurrentMember Long userId,
+    public ResponseEntity<FastApiResponse> create(@CurrentMember Long userId,
                                                             @RequestBody AppointmentCreateRequest appointmentCreateRequest) {
         AppointmentCreateResponse result = appointmentManageService.create(userId, appointmentCreateRequest);
-        return ResponseEntity.ok(result);
+        FastApiResponse fastApiResponse = fastApiService.sendEntranceCodeAndUserIdToFastApi(result.entranceCode(), result.userId());
+
+        return ResponseEntity.ok(fastApiResponse);
     }
 
     @PostMapping("/enter")
@@ -86,9 +89,9 @@ public class AppointmentController {
     }
 
     @GetMapping("/report/{boardId}")
-    public ResponseEntity<String> updateReportCount(Long roomId) {
-        appointmentManageService.update(roomId);
+    public ResponseEntity<String> updateReportCount(
+        @PathVariable Long boardId) {
+        appointmentManageService.update(boardId);
         return ResponseEntity.ok(SuccessCode.UPDATE_SUCCESS.getMessage());
     }
-
 }

--- a/src/main/java/com/example/gonggang/domain/appointment/domain/AppointmentParticipant.java
+++ b/src/main/java/com/example/gonggang/domain/appointment/domain/AppointmentParticipant.java
@@ -14,7 +14,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,12 +34,12 @@ public class AppointmentParticipant extends BaseTimeEntity {
 	@Column(nullable = false)
 	private boolean hasLeft;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
 	@JoinColumn(name = "participants_id")
 	@OnDelete(action = OnDeleteAction.CASCADE)
 	private Users participant;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
 	@JoinColumn(name = "appointment_room_id")
 	@OnDelete(action = OnDeleteAction.CASCADE)
 	private AppointmentRoom appointmentRoom;

--- a/src/main/java/com/example/gonggang/domain/external/fast_api/application/FastApiService.java
+++ b/src/main/java/com/example/gonggang/domain/external/fast_api/application/FastApiService.java
@@ -16,4 +16,8 @@ public class FastApiService {
 	public Map<String, Object> sendImageUrlAndMemberIdToFastApi(String imageUrl, String memberId) {
 		return fastApiClient.sendImageUrlAndMemberId(imageUrl, memberId);
 	}
+
+	public Map<String, Object> sendEntranceCodeAndUserIdToFastApi(String entranceCode, int userId) {
+		return fastApiClient.sendEntranceCodeAndUserId(entranceCode, userId);
+	}
 }

--- a/src/main/java/com/example/gonggang/domain/external/fast_api/application/FastApiService.java
+++ b/src/main/java/com/example/gonggang/domain/external/fast_api/application/FastApiService.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.springframework.stereotype.Service;
 
+import com.example.gonggang.domain.external.fast_api.dto.FastApiResponse;
 import com.example.gonggang.domain.external.fast_api.feign.FastApiClient;
 
 import lombok.RequiredArgsConstructor;
@@ -13,11 +14,13 @@ import lombok.RequiredArgsConstructor;
 public class FastApiService {
 	private final FastApiClient fastApiClient;
 
-	public Map<String, Object> sendImageUrlAndMemberIdToFastApi(String imageUrl, String memberId) {
-		return fastApiClient.sendImageUrlAndMemberId(imageUrl, memberId);
+	public FastApiResponse sendImageUrlAndMemberIdToFastApi(String imageUrl, String memberId) {
+		Map<String, Object> response = fastApiClient.sendImageUrlAndMemberId(imageUrl, memberId);
+		return FastApiResponse.from(response);
 	}
 
-	public Map<String, Object> sendEntranceCodeAndUserIdToFastApi(String entranceCode, int userId) {
-		return fastApiClient.sendEntranceCodeAndUserId(entranceCode, userId);
+	public FastApiResponse sendEntranceCodeAndUserIdToFastApi(String entranceCode, Long userId) {
+		Map<String, Object> response = fastApiClient.sendEntranceCodeAndUserId(entranceCode, userId.intValue());
+		return FastApiResponse.from(response);
 	}
 }

--- a/src/main/java/com/example/gonggang/domain/external/fast_api/dto/FastApiResponse.java
+++ b/src/main/java/com/example/gonggang/domain/external/fast_api/dto/FastApiResponse.java
@@ -1,0 +1,11 @@
+package com.example.gonggang.domain.external.fast_api.dto;
+
+import java.util.Map;
+
+public record FastApiResponse(
+	Map<String, Object> response
+) {
+	public static FastApiResponse from(Map<String, Object> response) {
+		return new FastApiResponse(response);
+	}
+}

--- a/src/main/java/com/example/gonggang/domain/external/fast_api/feign/FastApiClient.java
+++ b/src/main/java/com/example/gonggang/domain/external/fast_api/feign/FastApiClient.java
@@ -14,4 +14,10 @@ public interface FastApiClient {
 		@RequestParam("file_url") String fileUrl,
 		@RequestParam("username") String username
 	);
+
+	@PostMapping("/send-code")
+	Map<String, Object> sendEntranceCodeAndUserId(
+		@RequestParam("entranceCode") String entranceCode,
+		@RequestParam("userId") int userId
+	);
 }

--- a/src/main/java/com/example/gonggang/domain/external/fast_api/feign/FastApiClient.java
+++ b/src/main/java/com/example/gonggang/domain/external/fast_api/feign/FastApiClient.java
@@ -15,9 +15,9 @@ public interface FastApiClient {
 		@RequestParam("username") String username
 	);
 
-	@PostMapping("/send-code")
+	@PostMapping("/save-code")
 	Map<String, Object> sendEntranceCodeAndUserId(
-		@RequestParam("entranceCode") String entranceCode,
-		@RequestParam("userId") int userId
+		@RequestParam("entrance_code") String entranceCode,
+		@RequestParam("user_id") int userId
 	);
 }

--- a/src/main/java/com/example/gonggang/domain/external/fast_api/feign/FastApiClient.java
+++ b/src/main/java/com/example/gonggang/domain/external/fast_api/feign/FastApiClient.java
@@ -15,7 +15,7 @@ public interface FastApiClient {
 		@RequestParam("username") String username
 	);
 
-	@PostMapping("/save-code")
+	@PostMapping("/entrance-codes")
 	Map<String, Object> sendEntranceCodeAndUserId(
 		@RequestParam("entrance_code") String entranceCode,
 		@RequestParam("user_id") int userId

--- a/src/main/java/com/example/gonggang/domain/free_time/api/FreeTimeController.java
+++ b/src/main/java/com/example/gonggang/domain/free_time/api/FreeTimeController.java
@@ -1,11 +1,11 @@
 package com.example.gonggang.domain.free_time.api;
 
+import com.example.gonggang.domain.external.fast_api.dto.FastApiResponse;
 import com.example.gonggang.domain.free_time.application.FreeTimeManageService;
 import com.example.gonggang.domain.free_time.dto.request.FreeTimeRequest;
 import com.example.gonggang.domain.free_time.dto.response.FreeTimeAllResponse;
 import com.example.gonggang.global.config.success.SuccessCode;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -46,7 +46,7 @@ public class FreeTimeController implements FreeTimeApi {
 	) {
 		ImageUploadResponse response = freeTimeImageService.uploadImage(memberId, file);
 
-		Map<String, Object> fastApiResponse = fastApiService.sendImageUrlAndMemberIdToFastApi(
+		FastApiResponse fastApiResponse = fastApiService.sendImageUrlAndMemberIdToFastApi(
 			response.imageUrl(), response.memberId().toString()
 		);
 

--- a/src/main/java/com/example/gonggang/domain/free_time/application/FreeTimeSaveService.java
+++ b/src/main/java/com/example/gonggang/domain/free_time/application/FreeTimeSaveService.java
@@ -1,5 +1,6 @@
 package com.example.gonggang.domain.free_time.application;
 
+import com.example.gonggang.domain.external.fast_api.dto.FastApiResponse;
 import com.example.gonggang.domain.free_time.dto.request.FreeTimeRequest;
 import com.example.gonggang.domain.free_time.dto.request.FreeTimeRequestItem;
 import java.time.LocalTime;
@@ -29,8 +30,9 @@ public class FreeTimeSaveService {
 	private final UserGetService userGetService;
 	private final FreeTimeGetService freeTimeGetService;
 
-	public List<FreeTimeResponse> saveFreeTimes(Map<String, Object> fastApiResponse) {
-		String memberIdStr = (String) fastApiResponse.get("user_name");
+	public List<FreeTimeResponse> saveFreeTimes(FastApiResponse fastApiResponse) {
+		Map<String, Object> responseMap = fastApiResponse.response();
+		String memberIdStr = (String) responseMap.get("user_name");
 		long memberId = Long.parseLong(memberIdStr);
 
 		Users user = userGetService.findByMemberId(memberId);
@@ -47,8 +49,9 @@ public class FreeTimeSaveService {
 
 	// 'output'을 추출하는 메서드
 	@SuppressWarnings("unchecked")
-	private Map<String, List<String>> extractSchedule(Map<String, Object> fastApiResponse) {
-		Object outputObj = fastApiResponse.get("output");
+	private Map<String, List<String>> extractSchedule(FastApiResponse fastApiResponse) {
+		Map<String, Object> responseMap = fastApiResponse.response();
+		Object outputObj = responseMap.get("output");
 
 		if (!(outputObj instanceof List)) {
 			throw new OutputIsNotListException();

--- a/src/main/java/com/example/gonggang/domain/free_time/domain/FreeTime.java
+++ b/src/main/java/com/example/gonggang/domain/free_time/domain/FreeTime.java
@@ -43,7 +43,7 @@ public class FreeTime extends BaseTimeEntity {
 	@Column(nullable = false)
 	private Weekday weekday;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
 	@JoinColumn(nullable = false)
 	@OnDelete(action = OnDeleteAction.CASCADE)
 	private Users user;

--- a/src/main/java/com/example/gonggang/domain/member/domain/Member.java
+++ b/src/main/java/com/example/gonggang/domain/member/domain/Member.java
@@ -17,7 +17,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,7 +41,7 @@ public class Member extends BaseTimeEntity {
 	@Column
 	private LocalDateTime deletedAt;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = FetchType.LAZY, optional = false)
 	@JoinColumn(name = "user_id", nullable = false)
 	@OnDelete(action = OnDeleteAction.CASCADE)
 	private Users user;

--- a/src/main/java/com/example/gonggang/domain/member/domain/Member.java
+++ b/src/main/java/com/example/gonggang/domain/member/domain/Member.java
@@ -56,6 +56,7 @@ public class Member extends BaseTimeEntity {
 	@Column
 	private String timeTableImageUrl;
 
+	@Enumerated(EnumType.STRING)
 	@Column
 	private RegisterType registerType;
 

--- a/src/main/java/com/example/gonggang/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/gonggang/global/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsUtils;
 
 import com.example.gonggang.domain.users.domain.Role;
 import com.example.gonggang.global.auth.jwt.filter.JwtAuthenticationFilter;
@@ -67,6 +68,7 @@ public class SecurityConfig {
 
 		http.authorizeHttpRequests(auth ->
 				auth.requestMatchers(getAuthWhitelist()).permitAll()
+					.requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
 					.requestMatchers(AUTH_ADMIN_ONLY).hasAuthority(Role.ADMIN.getRoleName())
 					.anyRequest().authenticated())
 			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- fastAPI 서버로 openfeign을 통해 입장코드를 보내는 기능을 제작했습니다.

### 제작 배경
- 현재 FastAPI 서버는 Notion DB에 저장된 unique_url을 기반으로, 같은 시간표를 가진 사용자들의 공강시간을 추출하는 교집합 알고리즘을 수행합니다.
- 이 unique_url이 각 사용자의 입장 코드로 활용되며, 해당 입장 코드는 Spring 서버에서 생성됩니다.
- 따라서, Spring 서버에서 생성된 입장 코드를 OpenFeign을 사용해 FastAPI 서버로 전달하고, FastAPI 서버는 이를 Notion DB에 저장합니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?
<img width="453" alt="image" src="https://github.com/user-attachments/assets/6988a052-ee3e-4e52-89f5-6bfae7fc16ef" />

- ERD 설계시 외래키를 Not Null로 저장을 하도록 설계했었습니다.
- 그런데, 기본 옵션으로 Nullable하게 칼럼이 만들어 졌고, 이를 해결하고자 했습니다.
- 예찬님이 찾아주셨는데, 기본 외래키 설정이 optional=true라고 합니다. (nullable = true)
- 그래서 이를 optional=false로 변경하여 외래키를 not null 상태로 바꿀 수 있었습니다.

<img width="372" alt="image" src="https://github.com/user-attachments/assets/5127e71e-3497-42cd-b3a2-f64120f8ab90" />

- 기존 Member와 User 의 관계는 OneToOne으로 설계했었습니다.
- 그런데, ManyToOne으로 선언되어 있었고, 이를 수정했습니다.

<br>

## 3. 관련 스크린샷을 첨부해주세요.

<img width="1137" alt="image" src="https://github.com/user-attachments/assets/c08634a0-3415-40d3-9e5c-2ee8634f0cf1" />

<img width="1017" alt="image" src="https://github.com/user-attachments/assets/7f81e2dd-17fe-42a9-88a2-ffa4f22df65d" />

- 저장이 잘 되는 것을 확인했습니다.
- api/appointment는 공강팟을 만드는 api로 해당 api를 요청하게 되면 입장 코드를 발급해주게 됩니다.
- 이때, 발급된 입장코드를 fastAPI 서버로 보내 notion DB의 unique_url에 저장하게 됩니다.

<br>

## 4. 완료 사항


<br>

## 5. 추가 사항
- closes #36 
