### PR TITLE
[feat] 공팟원들이 입장코드를 통해 입장할 때, openfeign으로 fastAPI 서버에 입장 코드를 보내는 기능 구현 완료

### DIFF
--- a/src/main/java/com/example/gonggang/domain/appointment/api/AppointmentController.java
+++ b/src/main/java/com/example/gonggang/domain/appointment/api/AppointmentController.java
@@ -20,6 +20,7 @@ import com.example.gonggang.domain.appointment.dto.request.AppointmentEnterReque
 import com.example.gonggang.domain.appointment.dto.response.AllAppointmentBoardResponse;
 import com.example.gonggang.domain.appointment.dto.response.AppointmentAllResponse;
 import com.example.gonggang.domain.appointment.dto.response.AppointmentCreateResponse;
+import com.example.gonggang.domain.appointment.dto.response.AppointmentEntranceResponse;
 import com.example.gonggang.domain.appointment.dto.response.AppointmentRemainingResponse;
 import com.example.gonggang.domain.appointment.dto.response.AppointmentsGetResponse;
 import com.example.gonggang.domain.external.fast_api.application.FastApiService;
@@ -39,19 +40,21 @@ public class AppointmentController {
 	@PostMapping
 	public ResponseEntity<FastApiResponse> create(@CurrentMember Long userId,
 		@RequestBody AppointmentCreateRequest appointmentCreateRequest) {
-		AppointmentCreateResponse result = appointmentManageService.create(userId, appointmentCreateRequest);
-		FastApiResponse fastApiResponse = fastApiService.sendEntranceCodeAndUserIdToFastApi(result.entranceCode(),
-			result.userId());
+		AppointmentCreateResponse response = appointmentManageService.create(userId, appointmentCreateRequest);
+		FastApiResponse fastApiResponse = fastApiService.sendEntranceCodeAndUserIdToFastApi(response.entranceCode(),
+			response.userId());
 
 		return ResponseEntity.ok(fastApiResponse);
 	}
 
 	@PostMapping("/entrance")
-	public ResponseEntity<String> create(@CurrentMember Long userId,
+	public ResponseEntity<FastApiResponse> create(@CurrentMember Long userId,
 		@RequestBody AppointmentEnterRequest appointmentEnterRequest) {
 
-		appointmentManageService.enter(userId, appointmentEnterRequest);
-		return ResponseEntity.ok(ENTER_SUCCESS.getMessage());
+		AppointmentEntranceResponse response = appointmentManageService.enter(userId, appointmentEnterRequest);
+		FastApiResponse fastApiResponse = fastApiService.sendEntranceCodeAndUserIdToFastApi(response.entranceCode(), response.userId());
+
+		return ResponseEntity.ok(fastApiResponse);
 	}
 
 	@GetMapping

--- a/src/main/java/com/example/gonggang/domain/appointment/application/AppointmentManageService.java
+++ b/src/main/java/com/example/gonggang/domain/appointment/application/AppointmentManageService.java
@@ -8,6 +8,7 @@ import com.example.gonggang.domain.appointment.dto.request.AppointmentEnterReque
 import com.example.gonggang.domain.appointment.dto.response.AllAppointmentBoardResponse;
 import com.example.gonggang.domain.appointment.dto.response.AppointmentAllResponse;
 import com.example.gonggang.domain.appointment.dto.response.AppointmentCreateResponse;
+import com.example.gonggang.domain.appointment.dto.response.AppointmentEntranceResponse;
 import com.example.gonggang.domain.appointment.dto.response.AppointmentRemainingResponse;
 import com.example.gonggang.domain.appointment.dto.response.AppointmentsGetResponse;
 import com.example.gonggang.domain.appointment.exception.AccessDeniedException;
@@ -59,10 +60,11 @@ public class AppointmentManageService {
     }
 
     @Transactional
-    public void enter(Long userId, AppointmentEnterRequest appointmentEnterRequest) {
+    public AppointmentEntranceResponse enter(Long userId, AppointmentEnterRequest appointmentEnterRequest) {
         Users user = userGetService.findByMemberId(userId);
-        AppointmentRoom appointmentRoom = appointmentRoomGetService.findByEnteranceCode(
-                appointmentEnterRequest.entranceCode());
+        String entranceCode = appointmentEnterRequest.entranceCode();
+
+        AppointmentRoom appointmentRoom = appointmentRoomGetService.findByEnteranceCode(entranceCode);
 
         checkAvailable(appointmentRoom, user);
 
@@ -70,6 +72,7 @@ public class AppointmentManageService {
                 false);
         appointmentParticipantSaveService.save(appointmentParticipant);
         appointmentRoom.plusCurrentParticipants();
+        return AppointmentEntranceResponse.of(user.getId(), entranceCode);
     }
 
     private void checkAvailable(AppointmentRoom appointmentRoom, Users user) {

--- a/src/main/java/com/example/gonggang/domain/appointment/dto/response/AppointmentEntranceResponse.java
+++ b/src/main/java/com/example/gonggang/domain/appointment/dto/response/AppointmentEntranceResponse.java
@@ -1,0 +1,10 @@
+package com.example.gonggang.domain.appointment.dto.response;
+
+public record AppointmentEntranceResponse(
+	long userId,
+	String entranceCode
+) {
+	public static AppointmentEntranceResponse of(long userId, String entranceCode) {
+		return new AppointmentEntranceResponse(userId, entranceCode);
+	}
+}


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
-  공팟원들이 입장코드를 통해 입장할 때, openfeign으로 fastAPI 서버에 입장 코드를 보내는 기능을 구현했습니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="1139" alt="image" src="https://github.com/user-attachments/assets/4abc22dc-f938-42ec-95aa-f71b31397121" />

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/c36a5b3d-95ca-4fda-b2ef-0d5f084c50be" />

- 김예찬씨가 만든 공팟방에 이동훈씨가 입장 코드를 입력하여 공강팟에 들어가는 플로우입니다.
- 입장이 완료 되어서 공팟원 userId를 반환하였고, Notion DB에서 해당 userId와 일치하는 name이 있는 튜플에 unique_url이 같은 값으로 저장된 것을 볼 수 있습니다.

<br>

## 4. 완료 사항

- closes #40 

<br>

## 5. 추가 사항
