### PR TITLE
[feat] openfegin을 활용해 fastAPI의 시간잡기 API로 요청하는 API 구현 완료

### DIFF
--- a/src/main/java/com/example/gonggang/domain/appointment/api/AppointmentController.java
+++ b/src/main/java/com/example/gonggang/domain/appointment/api/AppointmentController.java
@@ -1,8 +1,7 @@
 package com.example.gonggang.domain.appointment.api;
 
-import static com.example.gonggang.global.config.success.SuccessCode.*;
-
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -17,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.gonggang.domain.appointment.application.AppointmentManageService;
 import com.example.gonggang.domain.appointment.dto.request.AppointmentCreateRequest;
 import com.example.gonggang.domain.appointment.dto.request.AppointmentEnterRequest;
+import com.example.gonggang.domain.appointment.dto.request.AppointmentExtractTimeRequest;
 import com.example.gonggang.domain.appointment.dto.response.AllAppointmentBoardResponse;
 import com.example.gonggang.domain.appointment.dto.response.AppointmentAllResponse;
 import com.example.gonggang.domain.appointment.dto.response.AppointmentCreateResponse;
@@ -99,5 +99,15 @@ public class AppointmentController {
 		@PathVariable Long boardId) {
 		appointmentManageService.update(boardId);
 		return ResponseEntity.ok(SuccessCode.UPDATE_SUCCESS.getMessage());
+	}
+
+	@PostMapping("/meet")
+	public ResponseEntity<Map<String, Object>> createAppointment(
+		@CurrentMember Long userId,
+		@RequestBody AppointmentExtractTimeRequest request
+	) {
+		FastApiResponse fastApiResponse = fastApiService.sendEntranceCodeToFastApi(request.entranceCode());
+		Map<String, Object> result = appointmentManageService.processFastApiResponse(fastApiResponse.response(), userId, request.roomId());
+		return ResponseEntity.ok(result);
 	}
 }

--- a/src/main/java/com/example/gonggang/domain/appointment/api/AppointmentController.java
+++ b/src/main/java/com/example/gonggang/domain/appointment/api/AppointmentController.java
@@ -101,7 +101,7 @@ public class AppointmentController {
 		return ResponseEntity.ok(SuccessCode.UPDATE_SUCCESS.getMessage());
 	}
 
-	@PostMapping("/meet")
+	@PostMapping("/meeting")
 	public ResponseEntity<Map<String, Object>> createAppointment(
 		@CurrentMember Long userId,
 		@RequestBody AppointmentExtractTimeRequest request

--- a/src/main/java/com/example/gonggang/domain/appointment/application/AppointmentManageService.java
+++ b/src/main/java/com/example/gonggang/domain/appointment/application/AppointmentManageService.java
@@ -15,13 +15,19 @@ import com.example.gonggang.domain.appointment.exception.AccessDeniedException;
 import com.example.gonggang.domain.appointment.exception.AlreadyEnteredException;
 import com.example.gonggang.domain.appointment.exception.AppointmentRoomMaxAppointmentException;
 import com.example.gonggang.domain.common.Weekday;
+import com.example.gonggang.domain.external.fast_api.util.TimeFormater;
 import com.example.gonggang.domain.free_time.application.FreeTimeGetService;
 import com.example.gonggang.domain.free_time.domain.FreeTime;
 import com.example.gonggang.domain.free_time.dto.response.FreeTimeItem;
 import com.example.gonggang.domain.users.domain.Users;
 import com.example.gonggang.domain.users.service.UserGetService;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,7 +60,6 @@ public class AppointmentManageService {
 
         appointmentRoomSaveService.save(appointmentRoom);
         appointmentParticipantSaveService.save(appointmentParticipant);
-
 
         return AppointmentCreateResponse.toResponse(userId, code);
     }
@@ -168,5 +173,69 @@ public class AppointmentManageService {
     public void update(Long boardId) {
         AppointmentBoard appointmentBoard = appointmentBoardGetService.findById(boardId);
         appointmentBoard.increaseReportCount();
+    }
+
+    @Transactional(readOnly = true)
+    public Map<String, Object> processFastApiResponse(Map<String, Object> response, Long userId, Long roomId) {
+        Users user = userGetService.findByMemberId(userId);
+        AppointmentParticipant appointmentParticipant = participantGetService.findByParticipantAndRoom(user,
+            roomId);
+        if (!appointmentParticipant.isOwner()) {
+            throw new AccessDeniedException();
+        }
+
+        Map<String, List<String>> meets = extractMeets(response.get("meets"));
+        List<String> participants = extractParticipants(response.get("participants"));
+
+        List<Map<String, String>> timeSlots = transformMeets(meets);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("timeSlots", timeSlots);
+        result.put("participants", participants);
+
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, List<String>> extractMeets(Object meetsObject) {
+        if (meetsObject instanceof Map<?, ?>) {
+            return (Map<String, List<String>>) meetsObject;
+        }
+        throw new IllegalArgumentException("Invalid meets data type");
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> extractParticipants(Object participantsObject) {
+        if (participantsObject instanceof List<?>) {
+            return (List<String>) participantsObject;
+        }
+        throw new IllegalArgumentException("Invalid participants data type");
+    }
+
+    private List<Map<String, String>> transformMeets(Map<String, List<String>> meets) {
+        List<Map<String, String>> timeSlots = new ArrayList<>();
+
+        for (Map.Entry<String, List<String>> entry : meets.entrySet()) {
+            String dayKor = entry.getKey();
+
+            Weekday weekday = Weekday.fromKorean(dayKor);
+
+            for (String timeRange : entry.getValue()) {
+                String[] times = timeRange.split("-");
+                if (times.length == 2) {
+                    String startTime = TimeFormater.convertToTimeFormat(times[0]);
+                    String endTime = TimeFormater.convertToTimeFormat(times[1]);
+
+                    Map<String, String> timeSlot = new LinkedHashMap<>();
+                    timeSlot.put("weekday", weekday.name());
+                    timeSlot.put("startTime", startTime);
+                    timeSlot.put("endTime", endTime);
+
+                    timeSlots.add(timeSlot);
+                }
+            }
+        }
+
+        return timeSlots;
     }
 }

--- a/src/main/java/com/example/gonggang/domain/appointment/dto/request/AppointmentExtractTimeRequest.java
+++ b/src/main/java/com/example/gonggang/domain/appointment/dto/request/AppointmentExtractTimeRequest.java
@@ -1,0 +1,7 @@
+package com.example.gonggang.domain.appointment.dto.request;
+
+public record AppointmentExtractTimeRequest(
+	String entranceCode,
+	Long roomId
+) {
+}

--- a/src/main/java/com/example/gonggang/domain/external/fast_api/application/FastApiService.java
+++ b/src/main/java/com/example/gonggang/domain/external/fast_api/application/FastApiService.java
@@ -23,4 +23,9 @@ public class FastApiService {
 		Map<String, Object> response = fastApiClient.sendEntranceCodeAndUserId(entranceCode, userId.intValue());
 		return FastApiResponse.from(response);
 	}
+
+	public FastApiResponse sendEntranceCodeToFastApi(String entranceCode) {
+		Map<String, Object> response = fastApiClient.sendEntranceCode(entranceCode);
+		return FastApiResponse.from(response);
+	}
 }

--- a/src/main/java/com/example/gonggang/domain/external/fast_api/feign/FastApiClient.java
+++ b/src/main/java/com/example/gonggang/domain/external/fast_api/feign/FastApiClient.java
@@ -3,6 +3,7 @@ package com.example.gonggang.domain.external.fast_api.feign;
 import java.util.Map;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -19,5 +20,10 @@ public interface FastApiClient {
 	Map<String, Object> sendEntranceCodeAndUserId(
 		@RequestParam("entrance_code") String entranceCode,
 		@RequestParam("user_id") int userId
+	);
+
+	@GetMapping("/meet")
+	Map<String, Object> sendEntranceCode(
+		@RequestParam("entrance_code") String entranceCode
 	);
 }

--- a/src/main/java/com/example/gonggang/domain/external/fast_api/feign/FastApiClient.java
+++ b/src/main/java/com/example/gonggang/domain/external/fast_api/feign/FastApiClient.java
@@ -22,7 +22,7 @@ public interface FastApiClient {
 		@RequestParam("user_id") int userId
 	);
 
-	@GetMapping("/meet")
+	@GetMapping("/meeting")
 	Map<String, Object> sendEntranceCode(
 		@RequestParam("entrance_code") String entranceCode
 	);

--- a/src/main/java/com/example/gonggang/domain/external/fast_api/util/TimeFormater.java
+++ b/src/main/java/com/example/gonggang/domain/external/fast_api/util/TimeFormater.java
@@ -1,0 +1,11 @@
+package com.example.gonggang.domain.external.fast_api.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public final class TimeFormater {
+	public static String convertToTimeFormat(String time) {
+		int hour = Integer.parseInt(time);
+		return String.format("%02d:00", hour);
+	}
+}


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- openfegin을 활용해 fastAPI의 시간잡기 API로 요청하고 해당 응답값을 재정렬하는 기능을 구현하였습니다.
- 자세한 동작은 다음과 같습니다.

1. 스프링 서버에서 시간 잡기를 원하는 팟의 entranceCode와 roomId를 담은 AppointmentExtractTimeRequest DTO를 이용해 /api/appointment/meet 경로로 요청을 보냅니다.
2. 그러면 openfeign으로 fastAPI 서버의 GET /meet API로 보내지게 됩니다.
3. fastAPI 서버에서 유저의 입장 코드 리스트 중 인자로 요청된 entranceCode가 있는 유저들의 시간표를 이용해 시간 교집합을 구한 후 Response DTO를 응답으로 반환합니다.
4. fastAPI 서버로부터 받은 해당 응답 데이터를 엔티티 구조에 맞게 재구성합니다.


<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.

<img width="1144" alt="image" src="https://github.com/user-attachments/assets/3b7c4ef7-4437-4c75-9435-7840d52c0811" />

- 공팟장이 아니면 약속 잡기 기능을 실행하지 못하도록 구현했습니다.

<img width="958" alt="image" src="https://github.com/user-attachments/assets/14917a39-3185-4eb7-a768-692f0eaec910" />

- 약속 잡기 기능을 실행하면 fastAPI 서버로 요청이 보내지고 그 응답값을 재정렬하여 보여줍니다.


<br>

## 4. 완료 사항



<br>

## 5. 추가 사항
- closes #42 